### PR TITLE
Manifeste duzenlemeler. 

### DIFF
--- a/IstanbulHackerspaceApp/AndroidManifest.xml
+++ b/IstanbulHackerspaceApp/AndroidManifest.xml
@@ -3,34 +3,27 @@
     package="org.istanbulhs.istanbulhackerspaceapp"
     android:versionCode="3"
     android:versionName="1.11" >
+    
     <uses-sdk
         android:minSdkVersion="11"
-        android:targetSdkVersion="17" />    
+        android:targetSdkVersion="19" />
+        
     <permission
        android:name="org.istanbulhs.istanbulhackerspaceapp.permission.MAPS_RECEIVE"
        android:protectionLevel="signature"/>
+    
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION"/>
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>
     <uses-permission android:name="android.permission.ACCESS_MOCK_LOCATION"/>
 	<uses-permission android:name="org.istanbulhs.istanbulhackerspaceapp.permission.MAPS_RECEIVE"/>
-	<uses-feature android:glEsVersion="0x00020000" android:required="true" />
 	<uses-permission android:name="com.google.android.providers.gsf.permission.READ_GSERVICES"/>
 	<uses-permission android:name="android.permission.INTERNET"/>
 	<uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
 	<uses-permission android:name="android.permission.CALL_PHONE"/>
+	
 	<uses-feature android:name="android.hardware.telephony" android:required="false" />
-	<compatible-screens>
-        <!-- all small size screens -->
-        <screen android:screenSize="small" android:screenDensity="ldpi" />
-        <screen android:screenSize="small" android:screenDensity="mdpi" />
-        <screen android:screenSize="small" android:screenDensity="hdpi" />
-        <screen android:screenSize="small" android:screenDensity="xhdpi" />
-        <!-- all normal size screens -->
-        <screen android:screenSize="normal" android:screenDensity="ldpi" />
-        <screen android:screenSize="normal" android:screenDensity="mdpi" />
-        <screen android:screenSize="normal" android:screenDensity="hdpi" />
-        <screen android:screenSize="normal" android:screenDensity="xhdpi" />
-    </compatible-screens>
+	<uses-feature android:glEsVersion="0x00020000" android:required="true" />
+	
     <application
         android:allowBackup="true"
         android:icon="@drawable/ic_launcher"


### PR DESCRIPTION
xxhdpi olan Nexus 5 de yuklenmiyordu. Ayni sekilde S4 te falan da. compatible-screens kisimlarini kaldirdim. Gercekten gerekli mi? Baya bir cihazi engelliyor. 

targetSdkVersion=19 yaptim. En son versiyon.
